### PR TITLE
508 Compliance: Add role attribute to modal.

### DIFF
--- a/src/jquery.simplemodal.js
+++ b/src/jquery.simplemodal.js
@@ -339,6 +339,8 @@
 			// create the container
 			s.d.container = $('<div></div>')
 				.attr('id', s.o.containerId)
+				//Adding role attribute with value 'dialog' for 508 compliance.
+				.attr('role', 'dialog')
 				.addClass('simplemodal-container')
 				.css($.extend(
 					{position: s.o.fixed ? 'fixed' : 'absolute'},


### PR DESCRIPTION
## Description

Adding role="dialog" attribute to the simple modal container for screen readers to interpret the container div as a dialog modal.

## Testing

Tested manually that the screen readers say 'dialog' when mouse enters or tabbed inside the modal.

## Reviewers

@rchild-okta 
@ukilon-okta 